### PR TITLE
Work dash api speed pl v2

### DIFF
--- a/ansible/files/sonic_lab_devices.csv
+++ b/ansible/files/sonic_lab_devices.csv
@@ -19,3 +19,9 @@ vnut-l2snk-01,10.250.0.213/24,Force10-S6000,DevSonic,,sonic,
 vnut-l2msnk-01,10.250.0.214/24,Force10-S6000,DevSonic,,sonic,
 vnut-l2msnk-02,10.250.0.215/24,Force10-S6000,DevSonic,,sonic,
 vnut-l2snk-tg,10.250.0.221/24,IxiaChassis,DevIxiaChassis,,ixia,
+keysight-nss01,10.36.78.150/24,Mellanox-SN4280-O28,DevSonic,,sonic
+keysight-nss01-dpu0,10.36.78.150/24,Mellanox-SN4280-O28,DevSonic,,sonic
+keysight-nss01-dpu1,10.36.78.150/24,Mellanox-SN4280-O28,DevSonic,,sonic
+keysight-css01,10.36.77.121/24,Cisco-8102-28FH-DPU-O,DevSonic,,sonic
+keysight-css01-dpu0,10.36.77.121/24,Cisco-8102-28FH-DPU-O,DevSonic,,sonic
+sonic-mgmt-keysight,10.36.79.161/24,TestServ,Server,,ubuntu

--- a/ansible/lab
+++ b/ansible/lab
@@ -17,6 +17,10 @@ all:
             sonic_msft_lc_100G:
             sonic_cisco_vs:
             sonic_vnut:
+            sonic_nvidia_smartswitch:
+            sonic_nvidia_dpu:
+            sonic_cisco_smartswitch:
+            sonic_amd_dpu:
         fanout:
           hosts:
             str-7260-10:
@@ -69,6 +73,14 @@ all:
           ansible_host: 10.255.0.180
         ptf_vms5-1:
           ansible_host: 10.255.0.183
+        ptf_keysight-nss01:
+          ansible_host: 172.17.0.1
+          ansible_port: 2222
+          ansible_ssh_pass: pass
+        ptf_keysight-css01:
+          ansible_host: 172.17.0.1
+          ansible_port: 2222
+          ansible_ssh_pass: pass
 
 sonic_sn2700_40:
   vars:
@@ -331,3 +343,68 @@ sonic_vnut:
       hwsku: Force10-S6000
       serial_port: 9105
       num_asics: 1
+
+# ─── Keysight SmartSwitch lab ────────────────────────────────────────────────
+
+# ── Nvidia SmartSwitch (SN4280, 4 DPUs) ──
+sonic_nvidia_smartswitch:
+  vars:
+    hwsku: Mellanox-SN4280-O28
+    iface_speed: 400000
+    ansible_ssh_user: admin
+    ansible_ssh_pass: pass
+    ansible_altpassword: pass
+  hosts:
+    keysight-nss01:
+      ansible_host: 10.36.78.150
+
+# ── Cisco SmartSwitch (8102-28FH-DPU-O, 8 DPUs) ──
+sonic_cisco_smartswitch:
+  vars:
+    hwsku: Cisco-8102-28FH-DPU-O
+    iface_speed: 400000
+    ansible_ssh_user: admin
+    ansible_ssh_pass: pass
+    ansible_altpassword: pass
+  hosts:
+    keysight-css01:
+      ansible_host: 10.36.77.121
+
+# DPU hosts are SONiC instances accessed via the midplane network.
+# The last octet of the midplane IP determines dpu_index: 169.254.200.N → dpu(N-1)
+# NAT port-forwarding must be enabled on the NPU before tests run:
+#   sudo sonic-dpu-mgmt-traffic.sh inbound -e --dpus all --ports 5021,5022,5023,5024
+
+# Nvidia DPUs (up to 4: dpu0..dpu3)
+sonic_nvidia_dpu:
+  vars:
+    ansible_ssh_user: admin
+    ansible_ssh_pass: pass
+    ansible_altpassword: pass
+  hosts:
+    keysight-nss01-dpu0:
+      ansible_host: 10.36.78.150    # NPU IP — DPU reached via NAT port-forward
+      ansible_ssh_port: 5021        # NPU NAT-forwards :5021 → DPU0 :22
+    keysight-nss01-dpu1:
+      ansible_host: 10.36.78.150    # NPU IP — DPU reached via NAT port-forward
+      ansible_ssh_port: 5022        # NPU NAT-forwards :5022 → DPU1 :22
+
+# AMD/Pensando DPUs in the Cisco 8102 (up to 8: dpu0..dpu7)
+sonic_amd_dpu:
+  vars:
+    ansible_ssh_user: admin
+    ansible_ssh_pass: pass
+    ansible_altpassword: pass
+  hosts:
+    keysight-css01-dpu0:
+      ansible_host: 10.36.77.121    # NPU IP — DPU reached via NAT port-forward
+      ansible_ssh_port: 5021        # NPU NAT-forwards :5021 → DPU0 :22
+
+# server_keysight must be a group (not a host) — the framework calls
+# im.groups.get("server_keysight") to discover the test-server host.
+server_keysight:
+  hosts:
+    sonic-mgmt-keysight:
+      ansible_host: 10.36.79.161
+      ansible_user: dash
+      ansible_ssh_pass: "pass"

--- a/ansible/testbed.yaml
+++ b/ansible/testbed.yaml
@@ -301,3 +301,36 @@
   auto_recover: 'True'
   netns_mgmt_ip: 10.255.0.211/16
   comment: dualtor setup example
+
+- conf-name: keysight-nss01
+  group-name: vms-keysight-1
+  topo: smartswitch-nvidia
+  ptf_image_name: docker-ptf
+  ptf: ptf_keysight-nss01
+  ptf_ip: 10.36.78.200/24    # UPDATE: IP of the PTF Docker container on server_keysight
+  ptf_ipv6:
+  server: server_keysight
+  vm_base:
+  dut:
+    - keysight-nss01
+    - keysight-nss01-dpu0
+    - keysight-nss01-dpu1
+  inv_name: lab
+  auto_recover: 'False'
+  comment: Keysight SmartSwitch 10.36.78.150 - DPU speed test (DPU0/DPU1)
+
+- conf-name: keysight-css01
+  group-name: vms-keysight-2
+  topo: smartswitch-cisco
+  ptf_image_name: docker-ptf
+  ptf: ptf_keysight-css01
+  ptf_ip: 10.36.77.200/24
+  ptf_ipv6:
+  server: server_keysight
+  vm_base:
+  dut:
+    - keysight-css01
+    - keysight-css01-dpu0
+  inv_name: lab
+  auto_recover: 'False'
+  comment: Keysight Cisco SmartSwitch 10.36.77.121 - DPU0 speed test

--- a/ansible/vars/topo_smartswitch-cisco.yml
+++ b/ansible/vars/topo_smartswitch-cisco.yml
@@ -1,0 +1,42 @@
+---
+# Minimal SmartSwitch topology for Keysight lab — Cisco 8102-28FH-DPU-O:
+#   - Switch (NPU) at 10.36.77.121
+#   - Up to 8 DPUs via midplane (169.254.200.1 .. 169.254.200.8)
+#   - No neighbour VMs required for DASH API speed tests
+#
+# Network layout (DPU 0):
+#   NPU Ethernet224  <-> 18.0.202.0/31 <-> 18.0.202.1/31 <-> DPU Ethernet0
+#   DPU Loopback0: 221.0.0.1/32
+
+topology:
+  DPUs:
+    keysight-css01-dpu0:
+      vlans:
+        - 0
+        - 1
+      vm_offset: 0
+
+configuration_properties:
+  common:
+    dut_asn: 65100
+    dut_type: SonicHost
+    nhipv4: 18.0.202.0
+    nhipv6: FC00::1
+
+configuration:
+  keysight-css01-dpu0:
+    properties:
+      - common
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+          - 18.0.202.0
+    interfaces:
+      Loopback0:
+        ipv4: 221.0.0.1/32
+      Ethernet0:
+        ipv4: 18.0.202.1/31
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64

--- a/ansible/vars/topo_smartswitch-nvidia.yml
+++ b/ansible/vars/topo_smartswitch-nvidia.yml
@@ -1,0 +1,42 @@
+---
+# Minimal SmartSwitch topology for Keysight lab:
+#   - Switch (NPU) at 10.36.78.150
+#   - DPU 0 via midplane (169.254.200.1)
+#   - No neighbour VMs required for DASH API speed tests
+#
+# Network layout (DPU 0):
+#   NPU Ethernet224  <-> 10.0.0.56/31 <-> 10.0.0.57/31 <-> DPU Ethernet0
+#   DPU Loopback0: 221.0.0.1/32
+
+topology:
+  DPUs:
+    keysight-nss01-dpu0:
+      vlans:
+        - 0
+        - 1
+      vm_offset: 0
+
+configuration_properties:
+  common:
+    dut_asn: 65100
+    dut_type: SonicHost
+    nhipv4: 10.0.0.56
+    nhipv6: FC00::1
+
+configuration:
+  keysight-nss01-dpu0:
+    properties:
+      - common
+    bgp:
+      asn: 65200
+      peers:
+        65100:
+          - 10.0.0.56
+    interfaces:
+      Loopback0:
+        ipv4: 221.0.0.1/32
+      Ethernet0:
+        ipv4: 10.0.0.57/31
+    bp_interface:
+      ipv4: 10.10.246.1/24
+      ipv6: fc0a::2/64

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1335,6 +1335,10 @@ def fanouthosts(enhance_inventory, ansible_adhoc, tbinfo, conn_graph_facts, cred
         logging.info("Nut topology has no fanout")
         return fanout_hosts
 
+    if tbinfo['topo']['name'].startswith('smartswitch'):
+        logging.info("SmartSwitch topology has no fanout")
+        return fanout_hosts
+
     # Process Ethernet connections
 
     dev_conn = conn_graph_facts.get('device_conn', {})

--- a/tests/dash/configs/dash_api_speed_pl/render.py
+++ b/tests/dash/configs/dash_api_speed_pl/render.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+# Jinja2 generator for DASH Private-Link config (same JSON as dpugen/dash.py). CLI: python render.py [-o out] [-p params]; templates in templates/.
+
+import argparse
+import hashlib
+import ipaddress
+import os
+import socket
+import struct
+import sys
+import uuid
+from multiprocessing import Pool, cpu_count
+
+from jinja2 import Environment, FileSystemLoader
+
+
+# ============================================================================
+#  Default parameters  (mirrors dpugen/dflt_params.py)
+# ============================================================================
+DEFAULTS = {
+    'LOOPBACK':          '221.0.0.1',
+    'PAL':               '221.1.0.0',
+    'PAR':               '221.2.0.0',
+    'GATEWAY':           '222.0.0.1',
+    'DPUS':               8,
+    'VM_VNI':             1000,
+    'ENI_START':          1000,
+    'ENI_COUNT':          256,
+    'ENI_STEP':           1,
+    'ENI_L2R_STEP':       1000,
+    'ACL_NSG_COUNT':      5,
+    'ACL_RULES_NSG':      12800,
+    'IP_PER_ACL_RULE':    1,
+    'ACL_MAPPED_PER_NSG': 12800,
+    'MAC_L_START':        '00:1A:C5:00:00:01',
+    'MAC_R_START':        '00:1B:6E:00:00:01',
+    'MAC_STEP_ENI':       '00:00:00:18:00:00',
+    'IP_L_START':         '1.1.0.1',
+    'IP_R_START':         '1.4.0.1',
+    'IP_STEP1':           '0.0.0.1',
+    'IP_STEP_ENI':        '0.64.0.0',
+    'IP_STEP_NSG':        '0.2.0.0',
+    'TOTAL_OUTBOUND_ROUTES': 128000,
+    # Minimal mode: 1 outbound route + MINIMAL_MAPPINGS VNet mappings per ENI (vs full scale).
+    'MINIMAL_SINGLE_ENTRY': False,
+    'MINIMAL_MAPPINGS': 1,
+}
+
+
+# ============================================================================
+#  Conversion helpers
+# ============================================================================
+def ip2int(s):
+    # IPv4 string -> 32-bit integer.
+    return int(ipaddress.ip_address(s))
+
+
+def mac2int(s):
+    # MAC string -> 48-bit integer.
+    return int(s.replace(':', ''), 16)
+
+
+# ============================================================================
+#  Jinja2 custom filters
+# ============================================================================
+def filt_ipv4(n):
+    # Integer -> IPv4 string: 0x01040001 -> '1.4.0.1'
+    return socket.inet_ntoa(struct.pack('>I', int(n)))
+
+
+def filt_hex_hi16(n):
+    # Upper 2 bytes as 4-hex-digit string: 0x01040001 -> '0104'
+    return f'{(int(n) >> 16) & 0xFFFF:04x}'  # noqa: E231
+
+
+def filt_hex_lo16(n):
+    # Lower 2 bytes as 4-hex-digit string: 0x01040001 -> '0001'
+    return f'{int(n) & 0xFFFF:04x}'  # noqa: E231
+
+
+def vni_lehex(vni):
+    # VNI -> little-endian hex string: 2000 -> 'd007'
+    h = f'{vni:04x}'  # noqa: E231  # '07d0'
+    return h[2:4] + h[0:2]                      # 'd007'
+
+
+def guid(s):
+    # Deterministic UUID from string (MD5-based, matches dpugen).
+    return str(uuid.UUID(hex=hashlib.md5(s.encode('UTF-8')).hexdigest()))
+
+
+def mac_str(n):
+    # Integer -> 'XX:XX:XX:XX:XX:XX' MAC string.
+    h = f'{int(n):012X}'  # noqa: E231
+    return ':'.join(h[i:i + 2] for i in range(0, 12, 2))
+
+
+# ============================================================================
+#  Outbound-route computation (port of dpugen/dashgen/dash_route_table.py)
+# ============================================================================
+def _pick_block_mix(ips, target):
+    # Return [(block_bits, count), ...] tiling `ips` into blocks summing to `target` routes.
+    for bb in range(1, 17):
+        bs = 1 << bb
+        if bs > ips:
+            break
+        if ips % bs == 0 and (ips // bs) * bb == target:
+            return [(bb, ips // bs)]
+    for gap in range(1, 17):
+        for k1 in range(1, 17 - gap):
+            k2 = k1 + gap
+            bs1, bs2 = 1 << k1, 1 << k2
+            if bs2 > ips:
+                break
+            det = bs1 * k2 - bs2 * k1
+            if det == 0:
+                continue
+            x_num = ips * k2 - target * bs2
+            y_num = target * bs1 - ips * k1
+            if x_num % det or y_num % det:
+                continue
+            X, Y = x_num // det, y_num // det
+            if X >= 0 and Y >= 0:
+                return [(k1, X), (k2, Y)]
+    best_bb, best_r = 1, 0
+    for bb in range(1, 17):
+        bs = 1 << bb
+        if bs > ips:
+            break
+        r = (ips // bs) * bb
+        if r <= target and r > best_r:
+            best_bb, best_r = bb, r
+    return [(best_bb, ips // (1 << best_bb))]
+
+
+def _decompose_block(base_ip, block_bits):
+    # Non-summarizable decomposition of a 2^block_bits-IP block (gap at base+0; /32 at base+1, /31 at base+2, ...).
+    return [{'ip': base_ip + (1 << i), 'mask': 32 - i} for i in range(block_bits)]
+
+
+def compute_outbound_routes(ip_r_start_eni, eni_index, params, total_outbound_routes):
+    # Yield outbound route dicts for one ENI: {ip, mask, routing_type, [overlay_ip]}.
+    p = params
+    if p.get('MINIMAL_SINGLE_ENTRY'):
+        # Exactly one outbound route: dest /32 (IP_R_START) via the single VNet mapping.
+        yield {'ip': filt_ipv4(ip_r_start_eni), 'mask': 32, 'routing_type': 'vnet'}
+        return
+    num_nsg_groups = p['ACL_NSG_COUNT'] * 2
+    ips_per_nsg = p['ACL_RULES_NSG'] * p['IP_PER_ACL_RULE']
+    ip_step_nsg = ip2int(p['IP_STEP_NSG'])
+    ip_step1 = ip2int(p['IP_STEP1'])
+    mapped_ips_per_nsg = p['ACL_MAPPED_PER_NSG'] * p['IP_PER_ACL_RULE']
+
+    target_per_nsg = total_outbound_routes // num_nsg_groups if num_nsg_groups else 0
+    block_mix = (_pick_block_mix(ips_per_nsg, target_per_nsg)
+                 if (ips_per_nsg and target_per_nsg) else [])
+
+    if p['ACL_MAPPED_PER_NSG'] > 0:
+        gateway_ip = filt_ipv4(ip_r_start_eni)
+    elif p['ACL_MAPPED_PER_NSG'] == 0:
+        gateway_ip = filt_ipv4(ip2int(p['GATEWAY']) + ip_step1 * eni_index)
+    else:
+        raise ValueError(
+            f'ACL_MAPPED_PER_NSG <{p["ACL_MAPPED_PER_NSG"]}> cannot be < 0')
+
+    added = 0
+    for table_index in range(num_nsg_groups):
+        # IP_R_START ends in .1 by convention; -1 shifts to a power-of-2 boundary.
+        nsg_base = ip_r_start_eni + ip_step_nsg * table_index - 1
+        offset = 0
+        for bb, count in block_mix:
+            bs = 1 << bb
+            for _ in range(count):
+                is_mapped = offset < mapped_ips_per_nsg
+                base_ip = nsg_base + offset
+                for r in _decompose_block(base_ip, bb):
+                    entry = {
+                        'ip': filt_ipv4(r['ip']),
+                        'mask': r['mask'],
+                        'routing_type': 'vnet' if is_mapped else 'vnet_direct',
+                    }
+                    if not is_mapped:
+                        entry['overlay_ip'] = gateway_ip
+                    yield entry
+                added += bb
+                offset += bs
+
+    if added == 0:
+        network = ipaddress.IPv4Network(
+            f'{filt_ipv4(ip_r_start_eni)}/10', strict=False)
+        entry = {
+            'ip': str(network.network_address),
+            'mask': network.prefixlen,
+            'routing_type': 'vnet' if p['ACL_MAPPED_PER_NSG'] > 0 else 'vnet_direct',
+        }
+        if p['ACL_MAPPED_PER_NSG'] == 0:
+            entry['overlay_ip'] = gateway_ip
+        yield entry
+
+
+# ============================================================================
+#  Template environment
+# ============================================================================
+def make_env():
+    tpl_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'templates')
+    env = Environment(
+        loader=FileSystemLoader(tpl_dir),
+        trim_blocks=True,
+        lstrip_blocks=True,
+        keep_trailing_newline=True,
+    )
+    env.filters['ipv4'] = filt_ipv4
+    env.filters['hex_hi16'] = filt_hex_hi16
+    env.filters['hex_lo16'] = filt_hex_lo16
+    return env
+
+
+# ============================================================================
+#  File-generation workers  (picklable for multiprocessing)
+# ============================================================================
+def _postprocess(content):
+    # Match compact_json formatting: trailing space after line-ending commas, CRLF.
+    lines = content.split('\n')
+    lines = [line + ' ' if line.endswith(',') else line for line in lines]
+    return '\r\n'.join(lines)
+
+
+def _write(path, content):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, 'wb') as f:
+        f.write(_postprocess(content).encode('utf-8'))
+
+
+def _render_apl(args):
+    # Render one APL file.
+    output_dir, prefix, dpu_id, ctx = args
+    env = make_env()
+    tmpl = env.get_template('apl.json.j2')
+    path = os.path.join(output_dir, f'dpu{dpu_id}',
+                        f'{prefix}.dpu{dpu_id}.000apl.json')
+    _write(path, tmpl.render(**ctx))
+    return path
+
+
+def _render_grp(args):
+    # Render one route-group file (one per ENI, pushed before the eni/routes file).
+    output_dir, prefix, dpu_id, eni_global, ctx = args
+    env = make_env()
+    tmpl = env.get_template('grp.json.j2')
+    path = os.path.join(output_dir, f'dpu{dpu_id}',
+                        f'{prefix}.dpu{dpu_id}.{eni_global:03d}grp.json')  # noqa: E231
+    _write(path, tmpl.render(**ctx))
+    return path
+
+
+def _render_eni(args):
+    # Render one ENI file.
+    output_dir, prefix, dpu_id, eni_global, ctx = args
+    env = make_env()
+    tmpl = env.get_template('eni.json.j2')
+    path = os.path.join(output_dir, f'dpu{dpu_id}',
+                        f'{prefix}.dpu{dpu_id}.{eni_global:03d}eni.json')  # noqa: E231
+    _write(path, tmpl.render(**ctx))
+    return path
+
+
+def _render_map(args):
+    # Render one MAP file (the big one: ~64 000 entries).
+    output_dir, prefix, dpu_id, eni_global, ctx = args
+    env = make_env()
+    tmpl = env.get_template('map.json.j2')
+    path = os.path.join(output_dir, f'dpu{dpu_id}',
+                        f'{prefix}.dpu{dpu_id}.{eni_global:03d}map.json')  # noqa: E231
+    # Render fully then postprocess (stream would need line-buffered postprocessing)
+    _write(path, tmpl.render(**ctx))
+    return path
+
+
+# ============================================================================
+#  Main orchestrator
+# ============================================================================
+def generate(params, output_dir, prefix='pl_100'):
+    p = params
+    dpus = p['DPUS']
+    enis_per_dpu = p['ENI_COUNT'] // dpus
+
+    # Pre-convert address strings to integers for fast arithmetic
+    IP1 = ip2int(p['IP_STEP1'])
+    IP_ENI = ip2int(p['IP_STEP_ENI'])
+    IP_NSG = ip2int(p['IP_STEP_NSG'])
+    MAC_ENI = mac2int(p['MAC_STEP_ENI'])
+
+    # Per-ENI route split (matches dash.py: conf_total // ENI_COUNT).
+    per_eni_total_routes = p['TOTAL_OUTBOUND_ROUTES'] // p['ENI_COUNT']
+
+    apl_jobs = []
+    grp_jobs = []
+    eni_jobs = []
+    map_jobs = []
+
+    for dpu in range(dpus):
+        # ── Per-DPU base values ─────────────────────────────────────────
+        dpu_eni_start = p['ENI_START'] + dpu * enis_per_dpu * p['ENI_STEP']
+        dpu_loopback = str(ipaddress.ip_address(p['LOOPBACK']) + dpu * IP1)
+        dpu_pal = ip2int(p['PAL']) + dpu * enis_per_dpu * IP1
+        dpu_par = ip2int(p['PAR']) + dpu * enis_per_dpu * IP1
+        dpu_ip_l = ip2int(p['IP_L_START']) + dpu * enis_per_dpu * IP_ENI
+        dpu_ip_r = ip2int(p['IP_R_START']) + dpu * enis_per_dpu * IP_ENI
+        dpu_mac_l = mac2int(p['MAC_L_START']) + dpu * enis_per_dpu * MAC_ENI
+        dpu_vm_vni = p['VM_VNI'] + dpu * enis_per_dpu
+
+        # APL context
+        apl_jobs.append((output_dir, prefix, dpu, {
+            'eni_start': dpu_eni_start,
+            'loopback': dpu_loopback,
+        }))
+
+        # ── Per-ENI values ──────────────────────────────────────────────
+        for ei in range(enis_per_dpu):
+            eni_global = dpu * enis_per_dpu + ei   # 0..255  (for filename)
+            eni = dpu_eni_start + ei * p['ENI_STEP']  # 1000..1255
+            r_vni = eni + p['ENI_L2R_STEP']           # 2000..2255
+            eni_pal = dpu_pal + ei * IP1
+            eni_par = dpu_par + ei * IP1
+            eni_ip_l = dpu_ip_l + ei * IP_ENI
+            eni_ip_r = dpu_ip_r + ei * IP_ENI
+            eni_mac_l = dpu_mac_l + ei * MAC_ENI
+            eni_hex = hex(eni)[2:]
+
+            # GRP: per-ENI route group, pushed before its routes (order grp -> eni -> map).
+            grp_jobs.append((output_dir, prefix, dpu, eni_global, {
+                'eni':              eni,
+                'route_group_guid': guid(f'route-group-{eni}'),
+            }))
+
+            # ENI context — routes materialized as a list of dicts
+            routes = list(compute_outbound_routes(
+                eni_ip_r, eni_global, p, per_eni_total_routes))
+            eni_jobs.append((output_dir, prefix, dpu, eni_global, {
+                'eni':              eni,
+                'r_vni_id':         r_vni,
+                'vnet_guid':        guid(f'DASH_VNET_TABLE:vnet-{r_vni}'),  # noqa: E231
+                'mac_address':      mac_str(eni_mac_l),
+                'underlay_ip':      filt_ipv4(eni_pal),
+                'pl_underlay_sip':  dpu_loopback,
+                # Bluefield needs the encoding hi-group set (fd40/mask fffe); zeroed -> ENI dropped (sonic-mgmt#23765).
+                'pl_sip_encoding':  f'fd40::{vni_lehex(r_vni)}:64:ff71:0:0'  # noqa: E231
+                                    f'/fffe:0:0:ffff:ffff:ffff::',  # noqa: E231,E131
+                'vm_vni':           dpu_vm_vni,
+                'route_group_guid': guid(f'route-group-{eni}'),
+                'routes':           routes,
+                'local_ip':         filt_ipv4(eni_ip_l),
+                'vtep_remote':      filt_ipv4(eni_par),
+                'include_route_rule': dpus <= 4,
+            }))
+
+            # MAP context
+            map_jobs.append((output_dir, prefix, dpu, eni_global, {
+                'eni':                eni,
+                'r_vni_id':           r_vni,
+                'vtep_remote':        filt_ipv4(eni_par),
+                'eni_hex':            eni_hex,
+                # Bluefield: CA2PA overlay SIP mask must be bits 80-112 (wide /96 rejected); use 1:ffff:ffff:: (sonic-mgmt#23765).
+                'overlay_sip_prefix': f'1:100:{eni_hex}::'  # noqa: E231
+                                      f'/1:ffff:ffff::',  # noqa: E231,E131
+                'ip_r_start':         eni_ip_r,
+                # Minimal mode -> 1 nsg group / 1 mapping; else full nsg_count.
+                'nsg_count':          1 if p.get('MINIMAL_SINGLE_ENTRY') else p['ACL_NSG_COUNT'] * 2,
+                # Minimal mode -> MINIMAL_MAPPINGS mappings; else ACL_RULES_NSG.
+                'acl_rules_nsg':      (2 * p.get('MINIMAL_MAPPINGS', 1)
+                                       if p.get('MINIMAL_SINGLE_ENTRY') else p['ACL_RULES_NSG']),
+                'ip_step_nsg':        IP_NSG,
+            }))
+
+    # ── Render in parallel ──────────────────────────────────────────────
+    workers = min(cpu_count(), dpus)
+    print(f'Generating {len(apl_jobs)} APL + {len(grp_jobs)} GRP + {len(eni_jobs)} ENI '
+          f'+ {len(map_jobs)} MAP files  ({workers} workers) ...',
+          file=sys.stderr)
+
+    with Pool(workers) as pool:
+        for path in pool.imap_unordered(_render_apl, apl_jobs):
+            print(f'  {path}', file=sys.stderr)
+        for path in pool.imap_unordered(_render_grp, grp_jobs):
+            print(f'  {path}', file=sys.stderr)
+        for path in pool.imap_unordered(_render_eni, eni_jobs):
+            print(f'  {path}', file=sys.stderr)
+        for path in pool.imap_unordered(_render_map, map_jobs):
+            print(f'  {path}', file=sys.stderr)
+
+    print('Done.', file=sys.stderr)
+
+
+# ============================================================================
+#  CLI
+# ============================================================================
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Generate DASH Private-Link configs via Jinja2 templates')
+    parser.add_argument('-o', '--output', default='output',
+                        help='Output directory (default: ./output/)')
+    parser.add_argument('-p', '--params',
+                        help='Params file (Python dict, e.g. dflt_params.py)')
+    parser.add_argument('--prefix', default='pl_100',
+                        help='Filename prefix (default: pl_100)')
+    args = parser.parse_args()
+
+    params = dict(DEFAULTS)
+    if args.params:
+        with open(args.params) as f:
+            content = f.read()
+            # Support both bare dict and 'dflt_params = {...}' format
+            if 'dflt_params' in content:
+                ns = {}
+                exec(content, ns)
+                params.update(ns['dflt_params'])
+            else:
+                params.update(eval(content))
+
+    generate(params, args.output, args.prefix)

--- a/tests/dash/configs/dash_api_speed_pl/templates/apl.json.j2
+++ b/tests/dash/configs/dash_api_speed_pl/templates/apl.json.j2
@@ -1,0 +1,18 @@
+[
+    {
+        "DASH_APPLIANCE_TABLE:appliance-{{ eni_start }}": {
+            "sip": "{{ loopback }}",
+            "vm_vni": {{ eni_start }},
+            "local_region_id": 100,
+            "trusted_vnis_list": [
+                { "range": {"min": 100, "max": 100} },
+                { "range": {"min": 250, "max": 511} }
+            ]
+        },
+        "OP": "SET"
+    },
+    {
+        "DASH_ROUTING_TYPE_TABLE:privatelink": [{"action_name": "action-1", "action_type": "4_to_6"}, {"action_name": "action-2", "action_type": "staticencap", "encap_type": "nvgre", "vni": 100}],
+        "OP": "SET"
+    }
+]

--- a/tests/dash/configs/dash_api_speed_pl/templates/eni.json.j2
+++ b/tests/dash/configs/dash_api_speed_pl/templates/eni.json.j2
@@ -1,0 +1,29 @@
+[
+    {"DASH_VNET_TABLE:vnet-{{ r_vni_id }}": {"vni": {{ r_vni_id }}, "guid": "{{ vnet_guid }}"}, "OP": "SET"},
+    {
+        "DASH_ENI_TABLE:eni-{{ eni }}": {
+            "eni_id": "eni-{{ eni }}",
+            "mac_address": "{{ mac_address }}",
+            "underlay_ip": "{{ underlay_ip }}",
+            "admin_state": "enabled",
+            "vnet": "vnet-{{ r_vni_id }}",
+            "pl_underlay_sip": "{{ pl_underlay_sip }}",
+            "pl_sip_encoding": "{{ pl_sip_encoding }}",
+            "trusted_vnis_list": [{"value": {{ vm_vni }}}]
+        },
+        "OP": "SET"
+    },
+{# route-group-{{ eni }} is created in the per-ENI grp file (pushed first) so the SAI group exists before these routes — see render.py grp->eni->map order. #}
+{% for r in routes %}
+{% if r.routing_type == 'vnet' %}
+    {"DASH_ROUTE_TABLE:route-group-{{ eni }}:{{ r.ip }}/{{ r.mask }}": {"routing_type": "vnet", "vnet": "vnet-{{ r_vni_id }}"}, "OP": "SET"},
+{% else %}
+    {"DASH_ROUTE_TABLE:route-group-{{ eni }}:{{ r.ip }}/{{ r.mask }}": {"routing_type": "vnet_direct", "vnet": "vnet-{{ r_vni_id }}", "overlay_ip": "{{ r.overlay_ip }}"}, "OP": "SET"},
+{% endif %}
+{% endfor %}
+    {"DASH_ROUTE_TABLE:route-group-{{ eni }}:{{ local_ip }}/32": {"routing_type": "vnet", "vnet": "vnet-{{ r_vni_id }}"}, "OP": "SET"}{% if include_route_rule %},{% endif %}
+
+{% if include_route_rule %}
+    {"DASH_ROUTE_RULE_TABLE:eni-{{ eni }}:100:{{ vtep_remote }}/32": {"action_type": "decap", "priority": 0}, "OP": "SET"}
+{% endif %}
+]

--- a/tests/dash/configs/dash_api_speed_pl/templates/grp.json.j2
+++ b/tests/dash/configs/dash_api_speed_pl/templates/grp.json.j2
@@ -1,0 +1,3 @@
+[
+    {"DASH_ROUTE_GROUP_TABLE:route-group-{{ eni }}": {"guid": "{{ route_group_guid }}", "version": "1"}, "OP": "SET"}
+]

--- a/tests/dash/configs/dash_api_speed_pl/templates/map.json.j2
+++ b/tests/dash/configs/dash_api_speed_pl/templates/map.json.j2
@@ -1,0 +1,9 @@
+[
+{% for nsg in range(nsg_count) %}
+{% for acl in range(0, acl_rules_nsg, 2) %}
+{% set ip = ip_r_start + nsg * ip_step_nsg + acl %}
+    {"DASH_VNET_MAPPING_TABLE:vnet-{{ r_vni_id }}:{{ ip | ipv4 }}": {"routing_type": "privatelink", "underlay_ip": "{{ vtep_remote }}", "overlay_sip_prefix": "{{ overlay_sip_prefix }}", "overlay_dip_prefix": "2603:100:{{ eni_hex }}:0::{{ ip | hex_hi16 }}:{{ ip | hex_lo16 }}/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"}, "OP": "SET"},
+{% endfor %}
+{% endfor %}
+    {"DASH_ENI_ROUTE_TABLE:eni-{{ eni }}": {"group_id": "route-group-{{ eni }}"}, "OP": "SET"}
+]

--- a/tests/dash/dash_api_speed_common.py
+++ b/tests/dash/dash_api_speed_common.py
@@ -1,0 +1,481 @@
+# Helpers for test_dash_api_speed_pl: gNMI config push/cleanup + memory reporting (no dataplane pre-config; see the .md).
+import json
+import logging
+import os
+import re
+import shlex
+import time
+
+import pytest
+from gnmi_utils import GNMIEnvironment
+
+logger = logging.getLogger(__name__)
+
+# WIP: extracted gNMI client location (git-ignored, copied out-of-band); see the .md.
+GNMI_AGENT_EXTRACTED_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                        "gnmi_agent_extracted")
+
+_BATCH_VAL = 3000  # pl_100 sweet spot (see reference_dash_perf_facts)
+_VERIFY_SETTLE_SECS = 30  # poll DBSIZE up to this long for async commit to reach the sent count
+_VERIFY_POLL_SECS = 2     # gap between DBSIZE polls while settling
+
+# Rendered filename -> (index, kind), e.g. pl_100.dpu0.001eni.json -> (1, "eni").
+_FILE_INDEX_RE = re.compile(r"\.(\d{3})(apl|grp|eni|map)\.json$")
+
+# Push order apl->grp->eni->map: dashrouteorch needs the group before its routes, frozen once the ENI binds.
+_KIND_ORDER = {"apl": 0, "grp": 1, "eni": 2, "map": 3}
+
+_TRANSIENT_GNMI_MARKERS = ("unavailable", "socket closed", "failed to connect",
+                           "error reading server preface", "connection reset")
+
+
+def parse_file_index(filename):
+    # Return (index:int, kind:str) for a rendered config file, or (None, None).
+    m = _FILE_INDEX_RE.search(filename)
+    return (int(m.group(1)), m.group(2)) if m else (None, None)
+
+
+# ============================================================================
+#  Memory accounting
+# ============================================================================
+def _parse_mem_str(mem_str):
+    # Parse a docker memory string ('512MiB', '1.5GiB', '256kB') into MiB.
+    m = re.match(r"([\d.]+)\s*(B|kB|MiB|GiB|TiB)", mem_str.strip())
+    if not m:
+        return 0.0
+    val, unit = float(m.group(1)), m.group(2)
+    return val * {"B": 1 / (1024 * 1024), "kB": 1 / 1024, "MiB": 1,
+                  "GiB": 1024, "TiB": 1024 * 1024}.get(unit, 1)
+
+
+def _collect_free_memory(host):
+    # `free -m` system memory keys (MiB) for *host*.
+    result = {}
+    for line in host.shell("free -m", module_ignore_errors=True).get("stdout", "").splitlines():
+        if line.startswith("Mem:"):
+            parts = line.split()  # total used free shared buff/cache available
+            result["_system_total"] = float(parts[1])
+            result["_system_used"] = float(parts[2])
+            result["_system_free"] = float(parts[3])
+            if len(parts) >= 7:
+                result["_system_available"] = float(parts[6])
+    return result
+
+
+def _collect_memory(host):
+    # Per-container memory (MiB) + '_system_*' keys from `free -m`.
+    result = {}
+    # awk avoids Jinja2 clash with Go's {{.Name}}; cols: ID NAME CPU% MEM_USED / ...
+    out = host.shell("docker stats --no-stream | awk 'NR>1 {print $2\"\\t\"$4}'", module_ignore_errors=True)
+    for line in out.get("stdout", "").splitlines():
+        line = line.strip()
+        if line and "\t" in line:
+            name, used_str = line.split("\t", 1)
+            result[name.strip()] = _parse_mem_str(used_str.strip())
+    result.update(_collect_free_memory(host))
+    return result
+
+
+def _collect_redis_memory(dpuhost):
+    # DPU_APPL_DB used_memory totals + 2 sample VNET_MAPPING key sizes.
+    result = {}
+    info = dpuhost.shell("sonic-db-cli DPU_APPL_DB INFO MEMORY", module_ignore_errors=True)
+    for line in info.get("stdout", "").splitlines():
+        line = line.strip()
+        if line.startswith("used_memory:"):
+            try:
+                result["_used_memory"] = int(line.split(":")[1])
+            except ValueError:
+                pass
+        elif line.startswith("used_memory_human:"):
+            result["_used_memory_human"] = line.split(":", 1)[1].strip()
+
+    # SCAN not KEYS: KEYS blocks single-threaded redis on large keyspaces.
+    keys = dpuhost.shell("sonic-db-cli DPU_APPL_DB SCAN 0 MATCH 'DASH_VNET_MAPPING_TABLE:*' COUNT 50 2>/dev/null",
+                         module_ignore_errors=True)
+    for key in keys.get("stdout", "").splitlines()[1:3]:  # line 0 is the cursor
+        key = key.strip()
+        if not key:
+            continue
+        usage = dpuhost.shell(f"sonic-db-cli DPU_APPL_DB MEMORY USAGE '{key}'", module_ignore_errors=True)
+        try:
+            result[key] = int(usage.get("stdout", "0").strip())
+        except ValueError:
+            result[key] = 0
+    return result
+
+
+def _print_per_eni_load_times(timings, total_elapsed):
+    # Print appliance + per-ENI push times (grp/eni/map in load order) + SUM/WALL/avg.
+    apl_total = 0.0
+    per_eni = {}  # idx -> {grp, eni, map: secs}
+    for filename, elapsed in timings.items():
+        idx, kind = parse_file_index(filename)
+        if kind == "apl":
+            apl_total += elapsed
+        elif idx is not None:
+            per_eni.setdefault(idx, {})
+            per_eni[idx][kind] = per_eni[idx].get(kind, 0.0) + elapsed
+
+    sep = "=" * 72
+    print(sep + "\n  DASH API LOAD SPEED — PER-ENI LOAD TIMES\n" + sep)
+    print("  %-10s  %8s  %8s  %8s  %10s" % ("ENI", "grp", "eni", "map", "total"))
+    print("  " + "-" * 56)
+    print("  %-10s  %8s  %8s  %8s  %10.2f" % ("appliance", "", "", "", apl_total))
+    grand = apl_total
+    for idx in sorted(per_eni):
+        k = per_eni[idx]
+        row_total = sum(k.values())
+        grand += row_total
+        print("  %-10s  %8.2f  %8.2f  %8.2f  %10.2f"
+              % (f"eni {idx:03d}", k.get("grp", 0.0), k.get("eni", 0.0), k.get("map", 0.0), row_total))
+    print("  " + "-" * 56)
+    eni_count = len(per_eni)
+    print("  %-10s  %40.2f" % ("SUM(push)", grand))
+    print("  %-10s  %40.2f" % ("WALL TOTAL", total_elapsed))
+    if eni_count:
+        # average per-ENI push time = sum of ENI row totals / ENIs (appliance excluded).
+        print("  %-10s  %40.2f" % ("avg/ENI", (grand - apl_total) / eni_count))
+    print("  ENIs pushed: %d\n%s" % (eni_count, sep))
+
+
+def _delta_row(label, before, after):
+    # Print a 'label before after delta' MiB row.
+    print("  %-30s  %8.1f  %8.1f  %+8.1f" % (label, before, after, after - before))
+
+
+def _print_results(timings, total_elapsed, mem_before, mem_after,
+                   redis_before, redis_after, mem_timeline=None):
+    # Print per-file times + NPU/DPU container/system/Redis memory before/after.
+    sep = "=" * 72
+    print(sep + "\n  DASH API LOAD SPEED TEST — RESULTS\n" + sep)
+
+    print("\n  Per-file load times:")
+    print("  %-44s  %8s\n  %s" % ("File", "Time (s)", "-" * 56))
+    for filename, elapsed in timings.items():
+        print("  %-44s  %8.2f" % (filename, elapsed))
+    push_sum = sum(timings.values())
+    print("  " + "-" * 56)
+    print("  %-44s  %8.2f" % ("TOTAL (file pushes)", push_sum))
+    print("  %-44s  %8.2f" % ("WALL TOTAL", total_elapsed))
+    if timings:
+        print("  %-44s  %8.2f" % ("Average per file", push_sum / len(timings)))
+    print("  Files loaded: %d" % len(timings))
+
+    for host_label in ("NPU", "DPU"):
+        before, after = mem_before[host_label], mem_after[host_label]
+        containers = sorted(k for k in set(before) | set(after) if not k.startswith("_"))
+        print("\n  Memory usage — %s (MiB):" % host_label)
+        print("  %-30s  %8s  %8s  %8s\n  %s" % ("Container", "Before", "After", "Delta", "-" * 58))
+        tb = ta = 0.0
+        for name in containers:
+            b, a = before.get(name, 0.0), after.get(name, 0.0)
+            tb += b
+            ta += a
+            _delta_row(name, b, a)
+        print("  " + "-" * 58)
+        _delta_row("Containers total", tb, ta)
+        _delta_row("System used (free -m)", before.get("_system_used", 0.0), after.get("_system_used", 0.0))
+        _delta_row("System free", before.get("_system_free", 0.0), after.get("_system_free", 0.0))
+        _delta_row("System available", before.get("_system_available", 0.0), after.get("_system_available", 0.0))
+        sys_total = before.get("_system_total", after.get("_system_total", 0.0))
+        if sys_total:
+            print("  %-30s  %8.1f" % ("System total", sys_total))
+
+    if mem_timeline:
+        print("\n  Memory timeline — free memory after each file push (MiB):")
+        print("  %-6s  %-40s  %7s  %9s  %9s  %9s  %9s\n  %s"
+              % ("#", "File", "Ops", "NPU free", "NPU avail", "DPU free", "DPU avail", "-" * 96))
+        for e in mem_timeline:
+            print("  %-6s  %-40s  %7d  %9.0f  %9.0f  %9.0f  %9.0f"
+                  % (e["idx"], e["file"][:40], e["ops"], e["npu_free"], e["npu_available"],
+                     e["dpu_free"], e["dpu_available"]))
+        if len(mem_timeline) > 1:
+            print("  " + "-" * 96)
+            print("  %-6s  %-40s  %7s  %9.0f  %9.0f  %9.0f  %9.0f"
+                  % ("", "MINIMUM", "", min(e["npu_free"] for e in mem_timeline),
+                     min(e["npu_available"] for e in mem_timeline),
+                     min(e["dpu_free"] for e in mem_timeline),
+                     min(e["dpu_available"] for e in mem_timeline)))
+
+    print("\n  DPU Redis memory — DPU_APPL_DB (bytes):")
+    print("  %-52s  %10s  %10s  %10s\n  %s" % ("Key", "Before", "After", "Delta", "-" * 86))
+    rb, ra = redis_before.get("_used_memory", 0), redis_after.get("_used_memory", 0)
+    print("  %-52s  %10d  %10d  %+10d" % ("used_memory (total)", rb, ra, ra - rb))
+    print("  %-52s  %10s  %10s" % ("used_memory_human", redis_before.get("_used_memory_human", "n/a"),
+                                   redis_after.get("_used_memory_human", "n/a")))
+    for key in sorted(k for k in set(redis_before) | set(redis_after) if not k.startswith("_")):
+        b, a = redis_before.get(key, 0), redis_after.get(key, 0)
+        print("  %-52s  %10d  %10d  %+10d" % (key, b, a, a - b))
+    print(sep)
+
+
+# ============================================================================
+#  Config inspection
+# ============================================================================
+def _count_json_operations(filepath):
+    # Return (op_count, {table: {SET, DEL}}) for a config JSON file.
+    with open(filepath) as f:
+        operations = json.load(f)
+    tables = {}
+    for op in operations:
+        op_type = op.get("OP", "?")
+        for k in op:
+            if k == "OP":
+                continue
+            t = tables.setdefault(k.split(":")[0], {"SET": 0, "DEL": 0})
+            t[op_type] = t.get(op_type, 0) + 1
+    return len(operations), tables
+
+
+def _db_int(shell_result):
+    # Parse an integer (e.g. DBSIZE) from a host.shell() result; 0 on anything odd.
+    try:
+        return int((shell_result.get("stdout", "") or "0").strip() or 0)
+    except (ValueError, AttributeError):
+        return 0
+
+
+# ============================================================================
+#  gNMI transport detection + readiness
+# ============================================================================
+def _detect_server_tls(duthost, env):
+    # Return 'notls'/'tls'/'mtls' from the running telemetry process flags (CONFIG_DB certs often empty).
+    out = duthost.shell(
+        "docker exec %s bash -c \"ps -eo args | grep -- '--port %d' | grep -v grep\""  # noqa: E501
+        % (env.gnmi_container, env.gnmi_port), module_ignore_errors=True)
+    line = (out.get("stdout", "") or "").strip()
+    logger.info("NPU gNMI server cmdline: %s", line or "(not found)")
+    low = line.lower()
+    if not line or "--notls" in low or "-notls" in low:
+        return "notls"
+    if "allow_no_client_auth" in low:
+        return "tls"
+    return "mtls" if "ca_crt" in low else "tls"
+
+
+def _stage_npu_certs(duthost, env, dest_dir):
+    # Copy CA+server cert/key off the gnmi container to dest_dir (reused as client cert); returns paths or None.
+    files = {"ca": env.gnmi_ca_cert, "cert": env.gnmi_server_cert, "key": env.gnmi_server_key}
+    local = {}
+    for tag, name in files.items():
+        src = env.gnmi_cert_path + name
+        cp = duthost.shell("docker cp %s:%s /tmp/%s" % (env.gnmi_container, src, name),  # noqa: E231
+                           module_ignore_errors=True)
+        if cp.get("rc", 1) != 0:
+            logger.warning("  docker cp %s failed: %s", src, (cp.get("stderr", "") or "").strip()[:200])
+            return None
+        try:
+            duthost.fetch(src="/tmp/%s" % name, dest="%s/%s" % (dest_dir, name), flat=True)
+        except Exception as e:
+            logger.warning("  fetch %s failed: %s", name, e)
+            return None
+        local[tag] = os.path.join(dest_dir, name)
+        logger.info("  Staged NPU cert %s -> %s", name, local[tag])
+    return local
+
+
+def _gnmi_server_ready(localhost, ip, port, tls_paths=None):
+    # True iff a gNMI Capabilities RPC succeeds (TLS if tls_paths given).
+    if tls_paths:
+        probe = (
+            "import grpc; from pygnmi.spec.v080 import gnmi_pb2, gnmi_pb2_grpc as g; "  # noqa: E702
+            "creds=grpc.ssl_channel_credentials("
+            "root_certificates=open({ca!r},'rb').read(),"
+            "private_key=open({key!r},'rb').read(),"
+            "certificate_chain=open({cert!r},'rb').read()); "
+            "ch=grpc.secure_channel('{ip}:{port}',creds); "
+            "g.gNMIStub(ch).Capabilities(gnmi_pb2.CapabilityRequest(), timeout=6)"
+        ).format(ca=tls_paths["ca"], key=tls_paths["key"], cert=tls_paths["cert"], ip=ip, port=port)
+    else:
+        probe = (
+            "import grpc; from pygnmi.spec.v080 import gnmi_pb2, gnmi_pb2_grpc as g; "  # noqa: E702
+            f"g.gNMIStub(grpc.insecure_channel('{ip}:{port}'))."  # noqa: E231
+            "Capabilities(gnmi_pb2.CapabilityRequest(), timeout=6)")
+    out = localhost.shell("python3 -c %s" % shlex.quote(probe), module_ignore_errors=True)
+    return out.get("rc", 1) == 0
+
+
+def _wait_gnmi_ready(localhost, ip, port, timeout=600, interval=5, tls_paths=None):
+    # Block until the gNMI server answers a Capabilities RPC (or timeout).
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if _gnmi_server_ready(localhost, ip, port, tls_paths=tls_paths):
+            logger.info("gNMI server %s:%s is ready", ip, port)
+            return True
+        logger.info("gNMI server %s:%s not ready — waiting %ds ...", ip, port, interval)
+        time.sleep(interval)
+    logger.warning("gNMI server %s:%s not ready after %ds — proceeding anyway", ip, port, timeout)
+    return False
+
+
+# ============================================================================
+#  gNMI push / cleanup
+# ============================================================================
+def _prepare_gnmi(localhost, duthost, dpuhost, config_dir, creds, action="push"):
+    # Resolve gNMI target+transport, stage TLS certs, wait for readiness; returns a conn dict.
+    env = GNMIEnvironment(duthost)
+    ip, port, dpu_index = duthost.mgmt_ip, env.gnmi_port, dpuhost.dpu_index
+    extracted_dir = GNMI_AGENT_EXTRACTED_DIR
+    assert os.path.isdir(extracted_dir), (
+        "gNMI agent client not found at %s — copy gnmi_agent_extracted/ onto the "
+        "controller (git-ignored / WIP). See test_dash_api_speed_pl.md." % extracted_dir)
+
+    mode = _detect_server_tls(duthost, env)
+    tls_prefix, tls_paths = "", None
+    if mode in ("tls", "mtls"):
+        cert_dir = os.path.join(os.path.dirname(config_dir.rstrip("/\\")), "gnmi_certs")
+        os.makedirs(cert_dir, exist_ok=True)
+        tls_paths = _stage_npu_certs(duthost, env, cert_dir)
+        if tls_paths:
+            tls_prefix = "GNMI_CA=%s " % shlex.quote(tls_paths["ca"])
+            if mode == "mtls":
+                tls_prefix += "GNMI_CLIENT_CERT=%s GNMI_CLIENT_KEY=%s " % (
+                    shlex.quote(tls_paths["cert"]), shlex.quote(tls_paths["key"]))
+        else:
+            logger.warning("Server is %s but cert staging failed — %s will likely fail", mode.upper(), action)
+    logger.info("gNMI %s -> %s:%s (dpu %d, %s)", action, ip, port, dpu_index,
+                mode.upper() if tls_paths else "plaintext")
+
+    _wait_gnmi_ready(localhost, ip, port, tls_paths=tls_paths)
+    return {"ip": ip, "port": port, "dpu_index": dpu_index, "extracted_dir": extracted_dir,
+            "gnmi_user": shlex.quote(creds["sonicadmin_user"]),
+            "gnmi_pass": shlex.quote(creds["sonicadmin_password"]),
+            "tls_prefix": tls_prefix, "tls_paths": tls_paths}
+
+
+def _apply_gnmi_file(localhost, conn, cfg_path, attempts=8):
+    # Run gnmi_client update -f cfg_path; retry only on transient errors (no per-file pre-probe). File OP drives SET/DEL.
+    ip, port, tls_paths = conn["ip"], conn["port"], conn["tls_paths"]
+    cmd = (f"cd {conn['extracted_dir']} && {conn['tls_prefix']}PYTHONPATH=. python3 gnmi_client.py"
+           f" --batch_val {_BATCH_VAL} -l warning -t {ip}:{port} -i {conn['dpu_index']} -n 8"  # noqa: E231
+           f" -u {conn['gnmi_user']} -p {conn['gnmi_pass']} update -f {cfg_path}")
+    rc, stderr, stdout = -1, "", ""
+    for _ in range(attempts):
+        out = localhost.shell(cmd, module_ignore_errors=True)
+        rc, stderr, stdout = out.get("rc", -1), out.get("stderr", "") or "", out.get("stdout", "") or ""
+        if rc == 0 or not any(m in stderr.lower() for m in _TRANSIENT_GNMI_MARKERS):
+            break
+        _wait_gnmi_ready(localhost, ip, port, tls_paths=tls_paths)
+    return rc, stderr, stdout
+
+
+def load_config_via_gnmi(localhost, duthost, dpuhost, config_dir, files,
+                         creds, timings=None, mem_timeline=None, mem_every=1):
+    # [WIP] Push DASH config (apl->grp->eni->map) via gNMI; times each file, samples mem every mem_every files, returns counts {landed (DBSIZE delta), expected_total, per_table (SET ops sent), db_before/after}.
+    if timings is None:
+        timings = {}
+    if mem_timeline is None:
+        mem_timeline = []
+    mem_every = max(1, int(mem_every))
+    conn = _prepare_gnmi(localhost, duthost, dpuhost, config_dir, creds, action="push")
+
+    db_before = dpuhost.shell("sonic-db-cli DPU_APPL_DB DBSIZE", module_ignore_errors=True)
+    logger.info("DPU_APPL_DB DBSIZE before push: %s", db_before.get("stdout", "").strip())
+
+    file_info = []
+    expected_sets_by_table, expected_total_sets = {}, 0
+    for filename in files:
+        op_count, tables = _count_json_operations(os.path.join(config_dir, filename))
+        file_info.append((filename, op_count, tables))
+        for t, c in tables.items():
+            expected_sets_by_table[t] = expected_sets_by_table.get(t, 0) + c.get("SET", 0)
+            expected_total_sets += c.get("SET", 0)
+    file_info.sort(key=lambda fi: (parse_file_index(fi[0])[0] if parse_file_index(fi[0])[0] is not None else -1,
+                                   _KIND_ORDER.get(parse_file_index(fi[0])[1], 9)))
+
+    push_errors = []
+    for idx, (filename, op_count, tables) in enumerate(file_info, start=1):
+        summary = ", ".join("%s:%dS/%dD" % (t, tables[t]["SET"], tables[t]["DEL"]) for t in sorted(tables))
+        logger.info("  [%d/%d] pushing %s (%d ops: %s) ...", idx, len(files), filename, op_count, summary)
+
+        t_start = time.time()
+        rc, stderr, stdout = _apply_gnmi_file(localhost, conn, os.path.join(config_dir, filename))
+        elapsed = time.time() - t_start
+        timings[filename] = elapsed
+
+        reason = ("exit code %d" % rc if rc != 0 else
+                  "error string in output" if any(s in stderr for s in ("Traceback", "RpcError", "Set failed"))
+                  else "")
+        if reason:
+            logger.error("  [%d/%d] FAILED %s after %.2fs — %s\n  output (tail): %s",
+                         idx, len(files), filename, elapsed, reason, (stderr or stdout)[-3000:])
+            push_errors.append("%s: %s" % (filename, reason))
+        else:
+            logger.info("  [%d/%d] done %s %.2fs rc=%d", idx, len(files), filename, elapsed, rc)
+        print("  [%d/%d] %-40s  %6.2fs  %s" % (idx, len(files), filename, elapsed, "FAIL" if reason else "ok"))
+
+        # Sample free -m every mem_every files (always on the last); it's pure SSH overhead (~130s at 32-ENI).
+        if idx % mem_every == 0 or idx == len(file_info):
+            try:
+                npu, dpu = _collect_free_memory(duthost), _collect_free_memory(dpuhost)
+                mem_timeline.append({"idx": idx, "file": filename, "ops": op_count,
+                                     "npu_free": npu.get("_system_free", 0), "npu_available": npu.get("_system_available", 0),
+                                     "dpu_free": dpu.get("_system_free", 0), "dpu_available": dpu.get("_system_available", 0)})
+            except Exception:
+                logger.debug("  [%d/%d] mem snapshot failed (non-fatal)", idx, len(files))
+
+    # Verify via DBSIZE delta (O(1)), not KEYS (blocks redis on large keyspaces).
+    # Poll until the delta reaches the sent SET count (async commit may lag the push) or timeout; _assert_programmed requires exact equality.
+    before_n = _db_int(db_before)
+    deadline = time.time() + _VERIFY_SETTLE_SECS
+    after_n = before_n
+    while True:
+        after_n = _db_int(dpuhost.shell("sonic-db-cli DPU_APPL_DB DBSIZE", module_ignore_errors=True))
+        if after_n - before_n >= expected_total_sets or time.time() >= deadline:
+            break
+        time.sleep(_VERIFY_POLL_SECS)
+    landed = after_n - before_n
+    logger.info("DPU_APPL_DB DBSIZE after push: %d (was: %d); landed delta=%d, expected=%d",
+                after_n, before_n, landed, expected_total_sets)
+    counts = {"landed": landed, "expected_total": expected_total_sets,
+              "per_table": expected_sets_by_table, "db_before": before_n, "db_after": after_n}
+
+    if push_errors:
+        pytest.fail("gNMI push had %d error(s):\n%s" % (len(push_errors), "\n".join("  - " + e for e in push_errors)))
+    return counts
+
+
+def cleanup_config_via_gnmi(localhost, duthost, dpuhost, config_dir, files, creds, mode="precise"):
+    # [WIP] Restore DPU state. mode="flushdb": one FLUSHDB (instant, wipes ALL keys, dedicated DPU only). mode="precise": gNMI DELETE each file in reverse via sibling *.del.json (safe on shared DPU, ~as slow as push).
+    if mode == "flushdb":
+        db_before = dpuhost.shell("sonic-db-cli DPU_APPL_DB DBSIZE", module_ignore_errors=True)
+        res = dpuhost.shell("sonic-db-cli DPU_APPL_DB FLUSHDB", module_ignore_errors=True)
+        db_after = dpuhost.shell("sonic-db-cli DPU_APPL_DB DBSIZE", module_ignore_errors=True)
+        ok = res.get("rc", -1) == 0
+        print("Cleanup (FLUSHDB): DPU_APPL_DB DBSIZE: %s -> %s%s"
+              % (db_before.get("stdout", "").strip(), db_after.get("stdout", "").strip(),
+                 "" if ok else " (FLUSHDB rc!=0)"))
+        return
+    conn = _prepare_gnmi(localhost, duthost, dpuhost, config_dir, creds, action="cleanup")
+    ordered = sorted(files, key=lambda f: (-(parse_file_index(f)[0] if parse_file_index(f)[0] is not None else -1),
+                                           -_KIND_ORDER.get(parse_file_index(f)[1], 9)))
+    print("Cleanup: deleting %d pushed config file(s) to restore DPU state ..." % len(ordered))
+    db_before = dpuhost.shell("sonic-db-cli DPU_APPL_DB DBSIZE", module_ignore_errors=True)
+    errors = 0
+    for idx, filename in enumerate(ordered, start=1):
+        src_path = os.path.join(config_dir, filename)
+        del_path = (src_path[:-5] if filename.endswith(".json") else src_path) + ".del.json"
+        try:
+            with open(src_path) as f:
+                ops = json.load(f)
+            for op in ops:
+                op["OP"] = "DEL"
+            with open(del_path, "w") as f:
+                json.dump(ops, f)
+        except Exception as e:
+            errors += 1
+            logger.warning("  cleanup [%d/%d] build DEL file failed %s: %s", idx, len(ordered), filename, e)
+            print("  cleanup [%d/%d] %-40s  SKIP(build)" % (idx, len(ordered), filename))
+            continue
+        rc, stderr, stdout = _apply_gnmi_file(localhost, conn, del_path, attempts=5)
+        ok = rc == 0 and "Traceback" not in stderr and "RpcError" not in stderr
+        if not ok:
+            errors += 1
+            logger.warning("  cleanup [%d/%d] delete FAILED %s rc=%d: %s",
+                           idx, len(ordered), filename, rc, (stderr or stdout)[-500:])
+        print("  cleanup [%d/%d] %-40s  %s" % (idx, len(ordered), filename, "ok" if ok else "FAIL"))
+
+    db_after = dpuhost.shell("sonic-db-cli DPU_APPL_DB DBSIZE", module_ignore_errors=True)
+    print("Cleanup done (%d error(s)); DPU_APPL_DB DBSIZE: %s -> %s"
+          % (errors, db_before.get("stdout", "").strip(), db_after.get("stdout", "").strip()))

--- a/tests/dash/test_dash_api_speed_pl.md
+++ b/tests/dash/test_dash_api_speed_pl.md
@@ -1,0 +1,289 @@
+# DASH API Speed Test (`test_dash_api_speed_pl.py`) — Run Guide
+
+## Overview
+
+`test_dash_api_speed_pl.py` measures how fast DASH private-link config loads
+onto a single DPU via gNMI. It:
+
+1. Resolves the **NPU** (`duthost`) and targeted **DPU** (`dpuhosts[dpu_index]`)
+   and prints both `hwsku` values.
+2. Renders per-ENI DASH config (appliance + route-group + ENI/routes + VNet
+   mappings) with `configs/dash_api_speed_pl/render.py` at the requested scale.
+3. Pushes every rendered file onto the DPU via the gNMI client
+   (`load_config_via_gnmi`), timing each push.
+4. Reports **per-ENI load time**, **total load time**, and **NPU + DPU memory**
+   (per-container, system `free -m`, and DPU `DPU_APPL_DB` Redis) before/after.
+
+### Scale knobs (top of the test file)
+
+| Variable | Default (when `None`) | Meaning |
+|----------|------------------------|---------|
+| `OVERRIDE_ENI_COUNT` | 64 on `Mellanox-SN4280-O28`, 32 on `Cisco-8102-28FH-DPU-O` | ENIs programmed on the DPU |
+| `OVERRIDE_MAPPING_COUNT` | 64K | VNet mappings **per ENI** |
+| `OVERRIDE_ROUTE_COUNT` | 10K | outbound routes **per ENI** |
+| `CLEANUP_MODE` | `"precise"` | `"precise"` = gNMI DELETE each pushed file; `"flushdb"` = one `FLUSHDB` of `DPU_APPL_DB` (instant, **dedicated DPU only** — wipes all keys) |
+| `MEM_TIMELINE_EVERY` | `1` | sample `free -m` (NPU+DPU) every Nth pushed file; raise to trim measurement overhead |
+
+Set any to an int for a smaller/larger run (e.g. a quick smoke test). Defaults
+target full private-link scale — those runs are large and slow.
+
+`CLEANUP_AFTER` (default `True`): once the measurement and reports are done, the
+test deletes the DASH config it just pushed so the DPU is left clean. With
+`CLEANUP_MODE="precise"` (default) it gNMI-DELETEs the same files in reverse
+order — only this run's keys are removed, pre-existing residue is untouched, but
+it costs roughly as long as the push (~460s at 32-ENI). With
+`CLEANUP_MODE="flushdb"` it issues a single `DPU_APPL_DB FLUSHDB` (seconds), which
+also clears any pre-existing keys — use it only on a dedicated test DPU. Cleanup
+time is **not** counted in the load measurement. Set `CLEANUP_AFTER=False` to
+leave the config in place (e.g. to inspect it or drive traffic afterwards).
+
+### gNMI client dependency (WIP, not committed)
+
+The push uses the extracted native gNMI client at
+`tests/dash/gnmi_agent_extracted/` (`gnmi_client.py`). That directory is
+**git-ignored** (`.gitignore`) and must be copied onto the controller /
+`sonic-mgmt` container out-of-band. The location is a single constant —
+`GNMI_AGENT_EXTRACTED_DIR` in `dash_api_speed_common.py` — update it (and drop
+the `.gitignore` entry) when the agent is packaged into the repo.
+
+---
+
+## Lab resources (already wired into `ansible/`)
+
+The two Keysight smartswitch testbeds are defined in this repo:
+
+| conf-name | topo | NPU host (hwsku) | NPU IP | DPU host(s) | DPU SSH (NAT on NPU) |
+|-----------|------|------------------|--------|-------------|----------------------|
+| `keysight-nss01` | `smartswitch-nvidia` | `keysight-nss01` (`Mellanox-SN4280-O28`) | 10.36.78.150 | `keysight-nss01-dpu0`, `keysight-nss01-dpu1` | dpu0 → :5021, dpu1 → :5022 |
+| `keysight-css01` | `smartswitch-cisco` | `keysight-css01` (`Cisco-8102-28FH-DPU-O`) | 10.36.77.121 | `keysight-css01-dpu0` | dpu0 → :5021 |
+
+Both use `--inventory=../ansible/lab`. The relevant inventory groups are
+`sonic_nvidia_smartswitch` (NPU) / `sonic_nvidia_dpu` (BlueField DPUs) for the
+Nvidia testbed, and `sonic_cisco_smartswitch` (NPU) / `sonic_amd_dpu`
+(AMD/Pensando DPUs) for the Cisco testbed; the test server is the
+`server_keysight` group (`sonic-mgmt-keysight` @ 10.36.79.161).
+
+## Prerequisites
+
+- The `sonic-mgmt` container running on the test server (`10.36.79.161`,
+  user `dash`), with this repo checked out.
+- The `dpuhosts` fixture reaches each DPU over a **NAT port-forward on the NPU**
+  (DPU hosts in the inventory point at the NPU IP with `ansible_ssh_port`
+  5021/5022). The test does **not** set this up — enable it **manually on the NPU,
+  and re-run it after every NPU reboot** (a reboot clears the forwarding):
+
+  ```bash
+  sudo sonic-dpu-mgmt-traffic.sh inbound -e --dpus all --ports 5021,5022,5023,5024
+  ```
+
+---
+
+## Running the test
+
+Run from `tests/` inside the `sonic-mgmt` container. **Both `ANSIBLE_*` exports
+are required** — `ansible.cfg` uses paths relative to the `tests/` CWD, so the
+custom ansible modules won't import without them — and **`-s` is required** to
+see the report. Use one of the examples below.
+
+---
+
+## NVIDIA SmartSwitch example
+
+NVIDIA BlueField DPU smartswitch (`keysight-nss01`, DPUs `-dpu0..-dpu3`):
+
+```bash
+cd /home/dash/sonic-mgmt/sonic-mgmt/tests
+export ANSIBLE_LIBRARY=$PWD/../ansible/library
+export ANSIBLE_MODULE_UTILS=$PWD/../ansible/module_utils
+
+pytest dash/test_dash_api_speed_pl.py \
+  --testbed=keysight-nss01 \
+  --testbed_file=../ansible/testbed.yaml \
+  --inventory=../ansible/lab \
+  --host-pattern=keysight-nss01 \
+  --dpu-pattern=keysight-nss01-dpu0 \
+  --dpu_index=0 \
+  --cache-clear -v -s
+```
+
+- DPUs are NVIDIA BlueField; the NPU is a Mellanox SN4280 host.
+- Change `--dpu_index` (0–3) and `--dpu-pattern` together to target a
+  different DPU; use one whose midplane reachability is `True`.
+- Example output: `NPU hwsku : Mellanox-SN4280-O28`,
+  `DPU hwsku : Nvidia-bf3-com-dpu`.
+
+---
+
+## Cisco SmartSwitch example
+
+Cisco 8102 smartswitch with AMD DPUs (e.g. `keysight-css01`,
+DPUs `-dpu0..-dpu7`):
+
+```bash
+cd /home/dash/sonic-mgmt/sonic-mgmt/tests
+export ANSIBLE_LIBRARY=$PWD/../ansible/library
+export ANSIBLE_MODULE_UTILS=$PWD/../ansible/module_utils
+
+pytest dash/test_dash_api_speed_pl.py \
+  --testbed=keysight-css01 \
+  --testbed_file=../ansible/testbed.yaml \
+  --inventory=../ansible/lab \
+  --host-pattern=keysight-css01 \
+  --dpu-pattern=keysight-css01-dpu0 \
+  --dpu_index=0 \
+  --cache-clear -v -s
+```
+
+- DPUs are AMD; the NPU is a Cisco 8102 host (hwsku reports as a
+  `Cisco-...` string).
+- Cisco smartswitches expose up to **8** DPUs, so `--dpu_index` can be 0–7.
+  Only `dpu0` is wired in the inventory/testbed by default; add more
+  `keysight-css01-dpuN` entries to target others.
+- Example output: `NPU hwsku : Cisco-8102-28FH-DPU-O`,
+  `DPU hwsku : Pensando-elba`.
+
+---
+
+## Expected output
+
+Sample run below: **32 ENIs × 64K mappings/ENI × 10K routes/ENI** 
+(`OVERRIDE_ENI_COUNT=32`, mappings/routes at their defaults). This renders **97
+config files** (1 appliance + 32×{grp, eni, map}) and programs ~2.05M mappings +
+320K routes. Long per-file / per-ENI / timeline lists are elided with `...`.
+
+```
+==================== DASH API SPEED PL ====================
+NPU host   : keysight-nss01 or keysight-css01
+NPU hwsku  : Mellanox-SN4280-O28 or Cisco-8102-28FH-DPU-O
+DPU index  : 0
+DPU host   : keysight-nss01-dpu0 or keysight-css01-dpu0
+DPU hwsku  : Nvidia-bf3-com-dpu or Pensando-elba
+===========================================================
+Scale: ENIs=32, mappings/ENI=64000, routes/ENI=10000 (override None => hwsku/default; full-scale is slow)
+Render scale: ENI_COUNT=32, mappings/ENI=64000 (requested 64000), routes/ENI=10001 (requested 10000)
+Rendered 97 config files to push to hardware DPU0
+  [1/97] pl_100.dpu0.000apl.json                     0.67s  ok
+  [2/97] pl_100.dpu0.000grp.json                     0.66s  ok
+  [3/97] pl_100.dpu0.000eni.json                     2.12s  ok
+  [4/97] pl_100.dpu0.000map.json                    10.17s  ok
+  ...
+  [97/97] pl_100.dpu0.031map.json                   11.14s  ok
+Programmed (DPU_APPL_DB): landed 2368194 keys vs 2368194 SET ops sent [DASH_APPLIANCE_TABLE=1, DASH_ENI_ROUTE_TABLE=32, DASH_ENI_TABLE=32, DASH_ROUTE_GROUP_TABLE=32, DASH_ROUTE_RULE_TABLE=32, DASH_ROUTE_TABLE=320032, DASH_ROUTING_TYPE_TABLE=1, DASH_VNET_MAPPING_TABLE=2048000, DASH_VNET_TABLE=32]
+
+========================================================================
+  DASH API LOAD SPEED — PER-ENI LOAD TIMES
+========================================================================
+  ENI              grp       eni       map       total
+  --------------------------------------------------------
+  appliance                                       0.67
+  eni 000         0.66      2.12     10.17       12.95
+  eni 001         0.66      2.22     10.19       13.07
+  ...
+  eni 031         0.64      2.29     11.14       14.07
+  --------------------------------------------------------
+  SUM(push)                                     427.32
+  WALL TOTAL                                    559.64
+  avg/ENI                                        13.33
+  ENIs pushed: 32
+========================================================================
+
+========================================================================
+  DASH API LOAD SPEED TEST — RESULTS
+========================================================================
+
+  Per-file load times:
+  File                                          Time (s)
+  --------------------------------------------------------
+  pl_100.dpu0.000apl.json                           0.67
+  pl_100.dpu0.000grp.json                           0.66
+  pl_100.dpu0.000eni.json                           2.12
+  pl_100.dpu0.000map.json                          10.17
+  ...
+  TOTAL (file pushes)                             427.32
+  WALL TOTAL                                      559.64
+  Average per file                                  4.41
+  Files loaded: 97
+
+  Memory usage — NPU (MiB):
+  Container                         Before     After     Delta
+  ----------------------------------------------------------
+  gnmi                                61.0     229.6    +168.6
+  databasedpu1                         96.4    1209.3   +1113.0
+  syncd                             1110.0    1110.0      +0.0
+  ...
+  Containers total                  4568.7    5851.6   +1283.0
+  System used (free -m)             7920.0    9249.0   +1329.0
+  System free                     118585.0  115264.0   -3321.0
+  System available                120874.0  119545.0   -1329.0
+  System total                    128794.0
+
+  Memory usage — DPU (MiB):
+  Container                         Before     After     Delta
+  ----------------------------------------------------------
+  swss                               360.4    3632.1   +3271.7
+  syncd                              273.7    1565.7   +1292.0
+  ...
+  Containers total                  1375.1    5938.9   +4563.8
+  System used (free -m)            26771.0   31503.0   +4732.0
+  System free                      29627.0   25435.0   -4192.0
+  System available                 37371.0   32639.0   -4732.0
+  System total                     64142.0
+
+  DPU Redis memory — DPU_APPL_DB (bytes):
+  Key                                                       Before       After       Delta
+  --------------------------------------------------------------------------------------
+  used_memory (total)                                      1676880  1171275776  +1169598896
+  used_memory_human                                          1.60M       1.09G
+========================================================================
+Cleanup: deleting 97 pushed config file(s) to restore DPU state ...
+  cleanup [1/97] pl_100.dpu0.031map.json                  ok
+  ...
+Cleanup done (0 error(s)); DPU_APPL_DB DBSIZE: 2368194 -> 0
+
+  PHASE BREAKDOWN (s): render=20.9  push+verify=559.6  cleanup=459.7  total=1040.3
+```
+
+### Timing & expected run time (32-ENI Nvidia run above)
+
+| Phase | What it does | Time |
+|-------|--------------|------|
+| `render` | Generate the 97 JSON config files locally | **~21 s** |
+| `push+verify` | gNMI push of all files + DPU_APPL_DB count verify (the measured window) | **~560 s** |
+| `cleanup` | gNMI DELETE of the same files (reverse order), DBSIZE → 0 | **~460 s** |
+| **total** | render + push + cleanup | **~1040 s (~17 min)** |
+
+Add ~1–2 min of pytest fixture setup (NPU/DPU facts, cert staging) on top, so
+budget **~18–19 min wall** end-to-end for a 32-ENI run. The dominant cost is the
+per-ENI **map** push (~10 s each × 32 ≈ 5 min) since each programs 64K mappings;
+`grp`/`eni` pushes are ~0.7 s / ~2.2 s. Full 64-ENI scale roughly doubles
+`push+verify` and `cleanup`. `avg/ENI` (13.33 s) is push time only — it excludes
+the appliance file and fixture overhead.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause / fix |
+|---------|--------------------|
+| `No module named 'ansible.module_utils.parse_utils'` / `No module named 'module_utils'` | The `ANSIBLE_LIBRARY` / `ANSIBLE_MODULE_UTILS` env vars are not set (see run command). |
+| `duthosts fixture failed: ... no attribute 'sonic_basic_facts'` | Same root cause — ansible custom modules failed to import; set the two env vars. |
+| `dpuhosts fixture failed: Host unreachable in the inventory` | (a) NAT not enabled on the NPU — run `sonic-dpu-mgmt-traffic.sh inbound -e ...`; **or** (b) the targeted DPU is down. Check `show chassis module midplane-status` on the NPU and target a DPU whose reachability is `True`. |
+| `conn_graph_facts failed` | The NPU/DPU host is missing from `ansible/files/sonic_lab_devices.csv`. The keysight hosts are already added there. |
+| `minigraph_facts failed: ... /etc/sonic/minigraph.xml` | The `fanouthosts` fixture tried to build fanout for a smartswitch (which has none). Fixed by the `smartswitch` guard in `tests/conftest.py:fanouthosts` (already in this repo). |
+| `IndexError` on `dpuhosts[dpu_index]` | `--dpu_index` is larger than the number of DPUs returned for `--dpu-pattern`. Lower it (NVIDIA: 0–3, Cisco: 0–7). |
+| Test skipped | The testbed topology is not `smartswitch`; check the testbed entry in `testbed.yaml`. |
+
+> The `conditional_mark: Failed to load minigraph basic facts` line printed at
+> collection time is **non-fatal** (the plugin ignores it) and does not affect
+> the result.
+
+---
+
+## Key files
+
+| File | Purpose |
+|------|---------|
+| `tests/dash/test_dash_api_speed_pl.py` | This test |
+| `tests/dash/test_dash_api_speed_pl.md` | This guide |
+| `tests/conftest.py` | Defines `dpuhosts` / `dpuhost` fixtures (NAT-gated) |
+| `tests/dash/conftest.py` | Defines the `dpu_index` fixture (`--dpu_index`) |

--- a/tests/dash/test_dash_api_speed_pl.py
+++ b/tests/dash/test_dash_api_speed_pl.py
@@ -1,0 +1,162 @@
+# DASH API load-speed test: render per-ENI private-link config, push via gNMI, report per-ENI/total time + memory. Scale via OVERRIDE_* below; see test_dash_api_speed_pl.md.
+import fnmatch
+import importlib.util
+import logging
+import os
+import shutil
+import sys
+import tempfile
+import time
+
+import pytest
+from dash_api_speed_common import (
+    _collect_memory,
+    _collect_redis_memory,
+    _print_per_eni_load_times,
+    _print_results,
+    cleanup_config_via_gnmi,
+    load_config_via_gnmi,
+)
+
+# ── Scale overrides: int to override, None for the default ───────────────────
+OVERRIDE_ENI_COUNT = None        # None -> per-NPU-hwsku default below
+OVERRIDE_MAPPING_COUNT = None    # mappings per ENI; None -> 64K
+OVERRIDE_ROUTE_COUNT = None      # routes per ENI; None -> 10K
+CLEANUP_AFTER = True             # delete this run's config afterwards; False keeps it
+CLEANUP_MODE = "precise"         # "precise" (gNMI DELETE each file) or "flushdb" (instant, wipes all DPU_APPL_DB)
+MEM_TIMELINE_EVERY = 1           # sample free -m every Nth file (1=every file; higher=faster, fewer points)
+# ─────────────────────────────────────────────────────────────────────────────
+
+_DEFAULT_ENI_COUNT_BY_HWSKU = {"Mellanox-SN4280-O28": 64, "Cisco-8102-28FH-DPU-O": 32}
+_DEFAULT_MAPPING_COUNT = 64 * 1000
+_DEFAULT_ROUTE_COUNT = 10 * 1000
+
+# Load render.py as a module so its multiprocessing workers can pickle its funcs.
+_RENDER_PATH = os.path.join(os.path.dirname(__file__), "configs", "dash_api_speed_pl", "render.py")
+_render_spec = importlib.util.spec_from_file_location("dash_render", _RENDER_PATH)
+render = importlib.util.module_from_spec(_render_spec)
+sys.modules["dash_render"] = render
+_render_spec.loader.exec_module(render)
+
+logger = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.topology("smartswitch"),
+    pytest.mark.skip_check_dut_health,
+    pytest.mark.disable_loganalyzer,
+    pytest.mark.sanity_check(skip_sanity=True),
+]
+
+
+def _resolve_scale(npu_hwsku):
+    # Resolve (eni_count, mapping_count, route_count) from overrides + hwsku.
+    eni_count = OVERRIDE_ENI_COUNT or _DEFAULT_ENI_COUNT_BY_HWSKU.get(npu_hwsku)
+    assert eni_count, ("No default ENI count for NPU hwsku %r — set OVERRIDE_ENI_COUNT (known: %s)."
+                       % (npu_hwsku, ", ".join(_DEFAULT_ENI_COUNT_BY_HWSKU)))
+    return eni_count, OVERRIDE_MAPPING_COUNT or _DEFAULT_MAPPING_COUNT, OVERRIDE_ROUTE_COUNT or _DEFAULT_ROUTE_COUNT
+
+
+def _build_render_params(eni_count, mapping_count, route_count):
+    # Map per-ENI scale knobs onto render.DEFAULTS for one DPU; print actual map/route counts (decomposition may under-shoot) and return params.
+    p = dict(render.DEFAULTS)
+    p["DPUS"] = 1
+    p["ENI_COUNT"] = eni_count
+    p["MINIMAL_SINGLE_ENTRY"] = False
+    nsg_groups = p["ACL_NSG_COUNT"] * 2
+    p["ACL_RULES_NSG"] = max(2, 2 * (mapping_count // nsg_groups))
+    p["ACL_MAPPED_PER_NSG"] = p["ACL_RULES_NSG"]
+    p["TOTAL_OUTBOUND_ROUTES"] = route_count * eni_count
+
+    actual_maps = nsg_groups * (p["ACL_RULES_NSG"] // 2)
+    per_eni_routes = p["TOTAL_OUTBOUND_ROUTES"] // p["ENI_COUNT"]
+    # +1: the eni template emits an extra local_ip/32 route beyond the decomposed set.
+    actual_routes = len(list(render.compute_outbound_routes(
+        render.ip2int(p["IP_R_START"]), 0, p, per_eni_routes))) + 1
+    print("Render scale: ENI_COUNT=%d, mappings/ENI=%d (requested %d), routes/ENI=%d (requested %d)"
+          % (eni_count, actual_maps, mapping_count, actual_routes, route_count))
+    return p
+
+
+def _assert_programmed(counts, eni_count):
+    # Require exact: landed (DBSIZE delta) == sent SET ops (no KEYS scan; load polls for async-commit settle first).
+    landed = counts.get("landed", 0)
+    expected = counts.get("expected_total", 0)
+    per_table = counts.get("per_table", {})
+    rendered_enis = per_table.get("DASH_ENI_TABLE", 0)
+    print("Programmed (DPU_APPL_DB): landed %d keys vs %d SET ops sent [%s]"
+          % (landed, expected, ", ".join("%s=%d" % (t, per_table[t]) for t in sorted(per_table))))
+    missing = []
+    if rendered_enis != eni_count:
+        missing.append("rendered ENIs %d != %d" % (rendered_enis, eni_count))
+    if landed != expected:
+        missing.append("landed %d != %d sent" % (landed, expected))
+    assert not missing, "DASH config not exactly programmed in DPU_APPL_DB: " + "; ".join(missing)
+
+
+def test_dash_api_speed_pl(localhost, duthost, dpuhosts, dpu_index, creds):
+    # Render DASH config, push it via gNMI, report per-ENI/total time + memory.
+    dpuhost = dpuhosts[dpu_index]
+    npu_hwsku = duthost.facts.get("hwsku", "unknown")
+    dpu_hwsku = dpuhost.facts.get("hwsku", "unknown")
+    print("\n==================== DASH API SPEED PL ====================")
+    print("NPU host   : %s\nNPU hwsku  : %s" % (duthost.hostname, npu_hwsku))
+    print("DPU index  : %s\nDPU host   : %s\nDPU hwsku  : %s" % (dpu_index, dpuhost.hostname, dpu_hwsku))
+    print("===========================================================")
+    logger.info("NPU host=%s hwsku=%s ; DPU[%s] host=%s hwsku=%s",
+                duthost.hostname, npu_hwsku, dpu_index, dpuhost.hostname, dpu_hwsku)
+
+    eni_count, mapping_count, route_count = _resolve_scale(npu_hwsku)
+    print("Scale: ENIs=%d, mappings/ENI=%d, routes/ENI=%d (override None => hwsku/default; full-scale is slow)"
+          % (eni_count, mapping_count, route_count))
+
+    # Render under the repo so the host docker daemon can bind-mount it (/tmp isn't shared).
+    render_output_dir = tempfile.mkdtemp(prefix="dash_cfg_", dir=os.path.dirname(os.path.abspath(__file__)))
+    logger.info("Rendering DASH configs into %s", render_output_dir)
+    params = _build_render_params(eni_count, mapping_count, route_count)
+    render_start = time.time()
+    render.generate(params, render_output_dir, prefix="pl_100")
+    render_elapsed = time.time() - render_start
+
+    # render always emits "dpu0" (DPUS=1); the push targets real hardware via the client's -i <dpu_index>.
+    config_dir = os.path.join(render_output_dir, "dpu0")
+    assert os.path.isdir(config_dir), f"Config directory not found after render: {config_dir}"
+    files = sorted(f for f in os.listdir(config_dir) if fnmatch.fnmatch(f, "*dpu0*.json"))
+    assert files, f"No JSON config files found in {config_dir}"
+    print("Rendered %d config files to push to hardware DPU%d" % (len(files), dpuhost.dpu_index))
+
+    mem_before = {"NPU": _collect_memory(duthost), "DPU": _collect_memory(dpuhost)}
+    redis_before = _collect_redis_memory(dpuhost)
+
+    timings, mem_timeline = {}, []
+    total_start = time.time()
+    try:
+        counts = load_config_via_gnmi(localhost, duthost, dpuhost, config_dir, files, creds,
+                                      timings, mem_timeline, mem_every=MEM_TIMELINE_EVERY)
+        _assert_programmed(counts, eni_count)
+    finally:
+        total_elapsed = time.time() - total_start  # measurement window (cleanup not counted)
+        try:
+            mem_after = {"NPU": _collect_memory(duthost), "DPU": _collect_memory(dpuhost)}
+            redis_after = _collect_redis_memory(dpuhost)
+            _print_per_eni_load_times(timings, total_elapsed)
+            _print_results(timings, total_elapsed, mem_before, mem_after, redis_before, redis_after, mem_timeline)
+        except Exception:
+            logger.exception("Failed to collect/print post-test results")
+
+        # Tear down this run's config (needs the rendered files, so before rmtree).
+        cleanup_elapsed = 0.0
+        if CLEANUP_AFTER:
+            try:
+                cleanup_start = time.time()
+                cleanup_config_via_gnmi(localhost, duthost, dpuhost, config_dir, files, creds, mode=CLEANUP_MODE)
+                cleanup_elapsed = time.time() - cleanup_start
+            except Exception:
+                logger.exception("Post-test cleanup failed (non-fatal)")
+
+        shutil.rmtree(render_output_dir, ignore_errors=True)
+        logger.info("Cleaned up rendered config dir: %s", render_output_dir)
+
+        # Phase breakdown (excludes pytest fixture setup/teardown overhead).
+        print("\n  PHASE BREAKDOWN (s): render=%.1f  push+verify=%.1f  cleanup=%.1f  total=%.1f"
+              % (render_elapsed, total_elapsed, cleanup_elapsed,
+                 render_elapsed + total_elapsed + cleanup_elapsed))


### PR DESCRIPTION
### Description of PR

Summary:
Adds `tests/dash/test_dash_api_speed_pl.py`, a test that measures how fast DASH
private-link config loads onto a single DPU via gNMI. It renders per-ENI config
(appliance + route-group + ENI/routes + VNet mappings) at a configurable scale,
pushes each file over gNMI, verifies it landed exactly (`DPU_APPL_DB DBSIZE`
delta == SET ops sent), and reports per-ENI/total load time plus NPU+DPU memory.
Also wires two Keysight SmartSwitch testbeds (Nvidia, Cisco) into ansible.

Fixes # (N/A — new test, no tracking issue)

### Type of change

- [ ] Bug fix
- [x] Testbed and Framework(new/improvement)
- [x] New Test case
    - [x] Skipped for non-supported platforms
- [ ] Test case improvement

### Back port request
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511
- [ ] 202512
- [ ] 202605

<!-- No back port: new test for the SmartSwitch topology, master only. -->

### Approach
#### What is the motivation for this PR?
Provide a repeatable way to measure DASH private-link config programming speed and
memory footprint on a SmartSwitch DPU, across vendors, at scale (up to 64 ENIs ×
64K mappings × 10K routes per ENI).

#### How did you do it?
- `configs/dash_api_speed_pl/render.py` + Jinja templates generate the per-ENI
  config files for a chosen scale.
- `dash_api_speed_common.py` pushes each file via gNMI (timing every push), then
  verifies exactly by polling `DPU_APPL_DB DBSIZE` until the key delta equals the
  rendered SET ops and asserting `landed == sent` (no `KEYS` scan, which blocks
  redis on large keyspaces). Reports per-container/system/redis memory before and
  after, and self-cleans via gNMI DELETE or `FLUSHDB`.
- Scale and behavior are controlled by `OVERRIDE_ENI_COUNT/MAPPING_COUNT/
  ROUTE_COUNT`, `CLEANUP_MODE`, and `MEM_TIMELINE_EVERY` at the top of the test.
- Added the `keysight-nss01`/`keysight-css01` testbeds (`testbed.yaml`, `lab`
  inventory, topo vars, lab-devices CSV) and a SmartSwitch fanout guard in
  `tests/conftest.py`.

#### How did you verify/test it?
- Nvidia BlueField-3 (`Mellanox-SN4280-O28`): full scale 32 ENIs × 64K mappings ×
  10K routes (~2.05M mappings, 320K routes) — PASS, exact `landed == sent`,
  self-cleanup to 0.
- Cisco 8102 + AMD/Pensando: PASS at 4 ENIs (exact, clean). Larger scale is bound
  by available DPU RAM.

#### Any platform specific information?
- Targets the `smartswitch` topology only (`pytest.mark.topology("smartswitch")`),
  so it is skipped elsewhere.
- The DPU is reached over a NAT port-forward on the NPU
  (`sonic-dpu-mgmt-traffic.sh inbound -e ...`), which must be enabled before runs.
- The push uses an extracted native gNMI client (`tests/dash/gnmi_agent_extracted/`,
  WIP) that is staged out-of-band and not committed; its location is the
  `GNMI_AGENT_EXTRACTED_DIR` constant.

#### Supported testbed topology if it's a new test case?
`smartswitch` (validated on `smartswitch-nvidia` and `smartswitch-cisco`).

### Documentation
Run guide and expected output: `tests/dash/test_dash_api_speed_pl.md` (in this PR).
